### PR TITLE
Ajout de dates par défaut à l'ajout d'un fichier

### DIFF
--- a/adapters/storage/stockagetb/StockageTB.php
+++ b/adapters/storage/stockagetb/StockageTB.php
@@ -299,7 +299,7 @@ class StockageTB implements CumulusInterface {
 			if (! empty($data[0])) {
 				// vérification des droits
 				$this->checkPermissionsOnFile($data[0]);
-				// ajout 
+				// ajout
 				return $data[0];
 			}
 		}
@@ -671,7 +671,7 @@ class StockageTB implements CumulusInterface {
 		$clausesString = implode($operator, $clauses);
 		// vérification des droits
 		$clausesString = '(' . $clausesString . ') AND ' . $this->getRightsCheckingClause();
-	
+
 		return $this->queryMultipleFiles($clausesString);
 	}
 
@@ -760,6 +760,7 @@ class StockageTB implements CumulusInterface {
 		$diskPath = $this->quote($storageInfo['disk_path']);
 		$mimetype = $this->quote($storageInfo['mimetype']);
 		$fileSize = $this->quote($storageInfo['file_size']);
+		$creationDate = $this->quote((new DateTime('now'))->format('Y-m-d H:i:s'));
 
 		// gestion du propriétaire
 		$owner = $this->quote($this->authAdapter->getUserId());
@@ -767,7 +768,7 @@ class StockageTB implements CumulusInterface {
 		// requete
 		$q = "INSERT INTO cumulus_files VALUES ($key, $name, $path"
 			. ", $diskPath, $mimetype, $fileSize, $owner, $groups, $permissions"
-			. ", $keywords, $license, $meta, DEFAULT, DEFAULT)";
+			. ", $keywords, $license, $meta, $creationDate, $creationDate)";
 		//echo "QUERY : $q\n";
 
 		$r = $this->db->exec($q);

--- a/adapters/storage/stockagetb/doc/dbstructure.sql
+++ b/adapters/storage/stockagetb/doc/dbstructure.sql
@@ -1,5 +1,10 @@
 DROP TABLE IF EXISTS `cumulus_files` ;
 
+
+---------------------------------------------------------------------
+-- The NOW() default value for DATETIME column works only for MySQL
+-- 5.6.5+
+---------------------------------------------------------------------
 CREATE  TABLE IF NOT EXISTS `cumulus_files` (
   `fkey` VARCHAR(40) NOT NULL COMMENT 'SHA1 hash of CONCAT(path,name) - "key" is a MySQL reserved word',
   `name` VARCHAR(255) NOT NULL COMMENT 'name of the file',
@@ -14,7 +19,7 @@ CREATE  TABLE IF NOT EXISTS `cumulus_files` (
   `license` VARCHAR(50) COMMENT 'license chosen by the owner : CC-BY-SA, GPL, LPRAB, copyright...',
   `meta` TEXT NULL COMMENT 'free metadata JSON string; useful for license, comments...',
   `creation_date` DATETIME NOT NULL DEFAULT NOW() COMMENT 'date when the file was added - immutable',
-  `last_modification_date` DATETIME NOT NULL DEFAULT NOW() COMMENT 'date when the file was modified for the last time',
+  `last_modification_date` DATETIME DEFAULT NULL ON UPDATE NOW() COMMENT 'date when the file was modified for the last time',
   PRIMARY KEY (`fkey`)
 )
 ENGINE = InnoDB


### PR DESCRIPTION
Les champs creation_date et last_modification_date reçoivent désormais une date par défaut coté PHP
